### PR TITLE
Change future processing to use future.call with plan(callr)

### DIFF
--- a/sources/VEGUI/FutureTaskProcessor.R
+++ b/sources/VEGUI/FutureTaskProcessor.R
@@ -7,8 +7,8 @@
 # it is not required to specify workers -- if not then it will default to future::availableCores()
 # use myNumTasks+1 because future uses one process for itself.
 
-if (!require(future)) install.packages("future")
-library(future)
+if (!require(future.callr)) install.packages("future.callr")
+library(future.callr)
 
 
 asyncTasksRunning <- list()
@@ -261,9 +261,9 @@ fakeDataProcessing <- function(name, duration, sys_sleep = FALSE) {
 } #end fakeDataProcessing
 
 
-testAsync <- function(loops = future::availableCores() - 1) {
-  plan(multiprocess)
-  print(paste0("future::availableCores(): ", future::availableCores()))
+testAsync <- function(loops = future.callr::availableCores() - 1) {
+  plan(callr)
+  print(paste0("future.callr::availableCores(): ", future.callr::availableCores()))
   loops <- 10 #
   baseWait <- 3
   for (loopNumber in 1:loops) {

--- a/sources/VEGUI/global.R
+++ b/sources/VEGUI/global.R
@@ -104,7 +104,12 @@ myFileTypes_ls <- list(
 
 # Get the volumes of local drive
 # Changes to this line may affect tests. See run_vegui_test.R
-volumeRoots = c('.' = '.', '..' = '..', getVolumes("")())
+# JR NOTE:
+# Should be fine, as long as the line starts with "volumeRoots = c("
+# Hacking on something un-parameterized like this violates the whole notion of
+# of what a "test" is.
+volumeRoots = c('Models' = '../models', '.' = '.', '..' = '..', getVolumes("")())
+if (length(volumeRoots)>3) names(volumeRoots)[c(2,3)] <- c( basename(getwd()), basename(normalizePath(file.path(getwd(),".."))) )
 
 # Define utility functions ----------------------------------------
 

--- a/sources/VEGUI/global.R
+++ b/sources/VEGUI/global.R
@@ -9,7 +9,7 @@ suppressPackageStartupMessages({
   library(shinyFiles)
   library(data.table)
   library(shinyBS)
-  library(future)
+  library(future.callr)
   library(testit)
   library(jsonlite)
   library(DT)
@@ -36,11 +36,12 @@ options(DT.options = list(dom = 'tip', rownames = 'f'))
 
 # Set future processors
 
-planType <- 'multiprocess'  # Will VEGUI work at all with sequential?
+planType <- 'callr'  # Will VEGUI work at all with sequential?
 
-if ( exists('planType') && planType == 'multiprocess'){
+if ( exists('planType') && planType == 'callr'){
   NWorkers <- max(availableCores()-1, 1)
-  plan(multiprocess, workers = NWorkers, gc=TRUE)
+#  plan(callr, workers = NWorkers, gc=TRUE)
+  plan(callr, workers = NWorkers)
 } else {
   plan(sequential)
 }


### PR DESCRIPTION
This change appears to work (formal testing TBD) and should allow VEGUI to run with multiple processors on a machine on which the current user has no administrative permissions.  In particular, by not using sockets for interprocess communications, future.callr eliminates the need to adjust the Windows firewall.

As issued, this pull request includes the commit separately requested to fix the dropdown for selecting a model, so that pull request (#8) should be reviewed first. 