### PR TITLE
Remove devtools from package DESCRIPTION Imports section

### DIFF
--- a/sources/modules/VE2001NHTS/DESCRIPTION
+++ b/sources/modules/VE2001NHTS/DESCRIPTION
@@ -18,7 +18,6 @@ LazyData: TRUE
 Depends: R (>= 3.1.0)
 Imports:
     visioneval,
-    devtools,
     usethis
 Suggests:
     knitr

--- a/sources/modules/VELandUse/DESCRIPTION
+++ b/sources/modules/VELandUse/DESCRIPTION
@@ -21,7 +21,6 @@ LazyData: TRUE
 Depends: R (>= 3.1.0)
 Imports:
     visioneval,
-    devtools,
     usethis,
     geosphere,
     fields,

--- a/sources/modules/VEReports/DESCRIPTION
+++ b/sources/modules/VEReports/DESCRIPTION
@@ -14,8 +14,7 @@ LazyData: TRUE
 Depends: R (>= 3.4.2)
 Imports:
     visioneval,
-    devtools,
-	usethis,
+    usethis,
     VEHouseholdTravel
 Suggests:
     knitr

--- a/sources/modules/VEScenario/DESCRIPTION
+++ b/sources/modules/VEScenario/DESCRIPTION
@@ -14,9 +14,8 @@ LazyData: TRUE
 Depends: R (>= 3.4)
 Imports:
     visioneval,
-    devtools,
-	usethis,
-    future,
+    usethis,
+    future.callr,
     jsonlite,
     data.table
 Suggests:

--- a/sources/modules/VESimHouseholds/DESCRIPTION
+++ b/sources/modules/VESimHouseholds/DESCRIPTION
@@ -17,7 +17,6 @@ LazyData: TRUE
 Depends: R (>= 3.1.0)
 Imports:
     visioneval,
-    devtools,
     usethis
 Suggests:
     knitr,

--- a/sources/modules/VESimTransportSupply/DESCRIPTION
+++ b/sources/modules/VESimTransportSupply/DESCRIPTION
@@ -18,7 +18,6 @@ LazyData: TRUE
 Depends: R (>= 3.1.0)
 Imports:
     visioneval,
-    devtools,
     usethis,
     VESimLandUse,
     VETransportSupply

--- a/sources/modules/VESyntheticFirms/DESCRIPTION
+++ b/sources/modules/VESyntheticFirms/DESCRIPTION
@@ -13,8 +13,7 @@ LazyData: TRUE
 Depends: R (>= 3.3.2)
 Imports:
     visioneval,
-    devtools,
-	usethis,
+    usethis,
     stats,
     reshape
 Suggests: knitr

--- a/sources/modules/VETransportSupply/DESCRIPTION
+++ b/sources/modules/VETransportSupply/DESCRIPTION
@@ -17,7 +17,6 @@ LazyData: TRUE
 Depends: R (>= 3.1.0)
 Imports:
     visioneval,
-    devtools,
     usethis
 Suggests:
     knitr

--- a/sources/modules/VETransportSupplyUse/DESCRIPTION
+++ b/sources/modules/VETransportSupplyUse/DESCRIPTION
@@ -14,8 +14,7 @@ LazyData: TRUE
 Depends: R (>= 3.4.2)
 Imports:
     visioneval,
-    devtools,
-	usethis
+    usethis
 Suggests:
     knitr
 VignetteBuilder: knitr


### PR DESCRIPTION
Due to refactoring of the "devtools" package, the functionality it previously provided for data management are now accessed through the "usethis" package.  Consequently, the package dependencies on devtools are obsolete (though devtools is still used as part of the build process).

This pull request removes "devtools" from the package dependency lists.  An incidental change was made to VEScenario, so it uses future.callr (and the callr plan) to perform multiprocessing, which is more flexible on Windows.  A separate pull request addresses the rest of the conversion to future.callr.