### PR TITLE
Fix a bug in writeToTableRD to retain dataset attributes when writing to existing dataset in datastore

### DIFF
--- a/sources/framework/visioneval/R/datastore.R
+++ b/sources/framework/visioneval/R/datastore.R
@@ -362,7 +362,7 @@ writeToTableRD <- function(Data_, Spec_ls, Group, Index = NULL) {
       )
     )
   } else {
-    Dataset <- readFromTableRD(Name, Table, Group)
+    Dataset <- readFromTableRD(Name, Table, Group, ReadAttr = TRUE)
     Attr_ls <- attributes(Dataset)
   }
   #Modify the loaded dataset

--- a/sources/modules/VEReports/DESCRIPTION
+++ b/sources/modules/VEReports/DESCRIPTION
@@ -11,7 +11,7 @@ Description: This package contains modules that creates reports for various
              performance metrics using visioneval framework.
 License: file LICENSE
 LazyData: TRUE
-Depends: R (>= 3.4.2)
+Depends: R (>= 3.4.0)
 Imports:
     visioneval,
     usethis,

--- a/sources/modules/VEScenario/DESCRIPTION
+++ b/sources/modules/VEScenario/DESCRIPTION
@@ -11,7 +11,7 @@ Description: This package contains modules that builds and runs
              scenarios for VERPAT model using visioneval framework.
 License: file LICENSE
 LazyData: TRUE
-Depends: R (>= 3.4)
+Depends: R (>= 3.4.0)
 Imports:
     visioneval,
     usethis,

--- a/sources/modules/VESyntheticFirms/DESCRIPTION
+++ b/sources/modules/VESyntheticFirms/DESCRIPTION
@@ -10,7 +10,7 @@ URL: https://github.com/gregorbj/VisionEval/sources/modules/VESyntheticFirms
 Description: VisionEval Synthetic Firms module
 License: Apache License 2.0
 LazyData: TRUE
-Depends: R (>= 3.3.2)
+Depends: R (>= 3.3.0)
 Imports:
     visioneval,
     usethis,

--- a/sources/modules/VETransportSupplyUse/DESCRIPTION
+++ b/sources/modules/VETransportSupplyUse/DESCRIPTION
@@ -11,7 +11,7 @@ Description: This package contains modules that creates attributes for utilizati
       transportation supplies.
 License: Apache License 2.0
 LazyData: TRUE
-Depends: R (>= 3.4.2)
+Depends: R (>= 3.4.0)
 Imports:
     visioneval,
     usethis


### PR DESCRIPTION
This is a bug fix to the writeToTableRD function. Currently when a dataset in the datastore is being overwritten with revised data, many or all of the attributes of the dataset in the datastore will be removed. This happens because the dataset first gets read from the datastore (by the readFromTableRD function) before rewriting and unless the dataset attributes are read as well, they will be overwritten with NA when the dataset is rewritten. The bug fix is to set the ReadAttr argument of the readFromTableRD function equal to TRUE.