### PR TITLE
Unused gc parameter in plan(callr); Fixes #49

### DIFF
--- a/sources/modules/VEScenario/R/VERPATResults.R
+++ b/sources/modules/VEScenario/R/VERPATResults.R
@@ -268,7 +268,7 @@ VERPATResults <- function(L){
   if ( exists('planType') && planType == 'callr'){
     NWorkers <- L$Global$Model$NWorkers
     NWorkers <- min(max(availableCores()-1, 1), NWorkers)
-    plan(callr, workers = NWorkers, gc=TRUE)
+    plan(callr, workers = NWorkers)
     message("Executing with ", NWorkers, " processors\n")
   } else {
     plan(sequential)
@@ -306,7 +306,7 @@ VERPATResults <- function(L){
 
   FinalResults_dt <- rbindlist(as.list(Results_env))
   rm(Results_env)
-  gc()
+  gc() # encourage R to release space we're done with
 
   ScenNames_ar <- basename(ScenariosPath_ar)
   ScenTab_dt <- data.table(Scenario = ScenNames_ar)

--- a/sources/modules/VEScenario/R/VERSPMResults.R
+++ b/sources/modules/VEScenario/R/VERSPMResults.R
@@ -379,7 +379,7 @@ VERSPMResults <- function(L){
   if ( exists('planType') && planType == 'callr'){
     NWorkers <- L$Global$Model$NWorkers
     NWorkers <- min(max(availableCores()-1, 1), NWorkers)
-    plan(callr, workers = NWorkers, gc=TRUE)
+    plan(callr, workers = NWorkers)
     message("Executing with ", NWorkers, " processors\n")
   } else {
     plan(sequential)
@@ -417,7 +417,7 @@ VERSPMResults <- function(L){
 
   FinalResults_dt <- rbindlist(as.list(Results_env))
   rm(Results_env)
-  gc()
+  gc() # Encourage R to release resources it is done with
 
   ScenNames_ar <- basename(ScenariosPath_ar)
   ScenTab_dt <- data.table(Scenario = ScenNames_ar)


### PR DESCRIPTION
Small edits to VEScenario package to eliminate a harmless warning about the obsolete 'gc' parameter on plan(callr,...).