### PR TITLE
Update CalculateRoadPerformance.R

### DIFF
--- a/sources/modules/VETravelPerformance/R/CalculateRoadPerformance.R
+++ b/sources/modules/VETravelPerformance/R/CalculateRoadPerformance.R
@@ -1733,7 +1733,7 @@ CalculateRoadPerformance <- function(L) {
     #Use binary search to find LambdaAdj factor for each marea
     for (ma in Ma[Ma != "None"]) {
       LambdaAdj_Ma[ma] <-
-        binarySearch(checkMatchLdvSplit, c(-1, 1), DoWtAve = TRUE, Tolerance = 0.01)
+        binarySearch(checkMatchLdvSplit, c(-3, 3), DoWtAve = TRUE, Tolerance = 0.01)
     }
     #Add to outputs list
     Out_ls$Global$Marea$LambdaAdj <- unattr(LambdaAdj_Ma)


### PR DESCRIPTION
"BinarySearch" function tries to match "checkMatchLdvSplit" function values to a value under .005 by tuning an adjusted lambda in the range of (-1,1) but this search range is not sufficient . it is now extended to (-3,3) to allow the BinarySearch function to find an adjusted lambda value for calibrating the road class split shares.