### PR TITLE
Correct erroneous call to checkProps function which omitted the 'azon…

### DIFF
--- a/sources/framework/visioneval/R/visioneval.R
+++ b/sources/framework/visioneval/R/visioneval.R
@@ -52,6 +52,9 @@
 #' loaded.
 #' @param SaveDatastore A string identifying whether if an existing datastore
 #' in the working directory should be saved rather than removed.
+#' @param SimulateRun A logical identifying whether the model run should be
+#' simulated: i.e. each step is checked to confirm that data of proper type
+#' will be present when the module is called.
 #' @return None. The function prints to the log file messages which identify
 #' whether or not there are errors in initialization. It also prints a success
 #' message if initialization has been successful.
@@ -65,7 +68,8 @@ initializeModel <-
     ModelParamFile = "model_parameters.json",
     LoadDatastore = FALSE,
     DatastoreName = NULL,
-    SaveDatastore = TRUE
+    SaveDatastore = TRUE,
+    SimulateRun = FALSE
   ) {
 
     #====================================================================
@@ -542,7 +546,9 @@ initializeModel <-
     #==================
     #SIMULATE MODEL RUN
     #==================
-    simDataTransactions(AllSpecs_ls)
+    if (SimulateRun) {
+      simDataTransactions(AllSpecs_ls)
+    }
 
     #===============================
     #CHECK AND PROCESS MODULE INPUTS

--- a/sources/modules/VEHouseholdVehicles/DESCRIPTION
+++ b/sources/modules/VEHouseholdVehicles/DESCRIPTION
@@ -2,7 +2,7 @@ Package: VEHouseholdVehicles
 Type: Package
 Title: Model household vehicles
 Version: 0.9.5
-Date: 11/6/18
+Date: 6/5/20
 Author: Brian Gregor [aut, cre], Aditya Gore <aditya.gore@rsginc.com> [cre]
 Maintainer: Brian Gregor <gregorb@or-analytics.com>, Aditya Gore <aditya.gore@rsginc.com>
 Copyright: AASHTO

--- a/sources/modules/VEHouseholdVehicles/R/CreateVehicleTable.R
+++ b/sources/modules/VEHouseholdVehicles/R/CreateVehicleTable.R
@@ -5,7 +5,7 @@
 #<doc>
 #
 ## CreateVehicleTable Module
-#### January 7, 2020
+#### June 5, 2020
 #
 #This module creates a vehicle table and populates it with household ID and geography fields.
 #

--- a/sources/modules/VEHouseholdVehicles/R/CreateVehicleTable.R
+++ b/sources/modules/VEHouseholdVehicles/R/CreateVehicleTable.R
@@ -288,8 +288,10 @@ CreateVehicleTable <- function(L) {
   Out_ls$Year$Vehicle$HhId <- HhId_Ve
   attributes(Out_ls$Year$Vehicle$HhId)$SIZE <- max(nchar(HhId_Ve))
   #Add vehicle ID to table
+  #Note: ignore group quarters households that are under 15 years old (i.e. are
+  #not driving age) by definition, these have no vehicle access.
   Out_ls$Year$Vehicle$VehId <-
-    paste(HhId_Ve, unlist(sapply(NumVeh_Hh, function(x) 1:x)), sep = "-")
+    paste(HhId_Ve, unlist(sapply(NumVeh_Hh[NumVeh_Hh > 0], function(x) 1:x)), sep = "-")
   attributes(Out_ls$Year$Vehicle$VehId)$SIZE <- max(nchar(Out_ls$Year$Vehicle$VehId))
   #Add Azone ID to table
   Out_ls$Year$Vehicle$Azone <- rep(L$Year$Household$Azone, NumVeh_Hh)

--- a/sources/modules/VESimLandUse/DESCRIPTION
+++ b/sources/modules/VESimLandUse/DESCRIPTION
@@ -2,7 +2,7 @@ Package: VESimLandUse
 Type: Package
 Title: Create simulated Bzones (SimBzones) with attributes
 Version: 0.95
-Date: 02/13/20
+Date: 06/01/20
 Author: Brian Gregor [aut, cre],
 Maintainer: Brian Gregor <gregorb@or-analytics.com>
 Copyright: AASHTO, ODOT

--- a/sources/modules/VESimLandUse/R/Initialize.R
+++ b/sources/modules/VESimLandUse/R/Initialize.R
@@ -4,7 +4,7 @@
 
 #<doc>
 ## Initialize Module
-#### December 3, 2019
+#### June 1, 2020
 #
 #Modules in the VESimLandUse package synthesize Bzones and their land use attributes as a function of Azone characteristics as well as data derived from the US Environmental Protection Agency's Smart Location Database (SLD) augmented with US Census housing and household income data, and data from the National Transit Database. Details on these data are included in the VESimLandUseData package. The combined dataset contains a number of land use attributes at the US Census block group level. The goal of Bzone synthesis to generate a set of SimBzones in each Azone that reasonably represent block group land use characteristics given the characteristics of the Azone, the Marea that the Azone is a part of, and scenario inputs provided by the user.
 #
@@ -1092,7 +1092,7 @@ Initialize <- function(L) {
       if (all(is.na(unlist(Out_ls$Data$Year$Azone[Names_])))) {
         Out_ls$Data$Year$Azone[Names_] <- NULL
       } else {
-        Out_ls$Data$Year$Azone[Names_] <- checkProps(Names_, "Azone")
+        Out_ls$Data$Year$Azone[Names_] <- checkProps(Names_, "Azone", "azone_gq_pop-prop_by_area-type.csv")
       }
     } else {
       Msg <- paste0(

--- a/sources/modules/VESimLandUse/R/SimulateHousing.R
+++ b/sources/modules/VESimLandUse/R/SimulateHousing.R
@@ -5,7 +5,7 @@
 #<doc>
 #
 ## SimulateHousing Module
-#### February 3, 2019
+#### June 1, 2020
 #
 #This module assigns a housing type, either single-family (SF) or multifamily (MF) to *regular* households based on the respective supplies of SF and MF dwelling units in the housing market to which the household is assigned (i.e. the Azone the household is assigned to) and on household characteristics. It then assigns each household to a SimBzone based on the household's housing type as well as the supply of housing by type and SimBzone. The module assigns non-institutional group quarters *households* to SimBzones randomly.
 #
@@ -530,6 +530,15 @@ SimulateHousing <- function(L) {
         GQPop_At <- splitIntegers(GQPop, GQProps_)
         At <- c("center", "inner", "outer", "fringe")
         names(GQPop_At) <- At
+        for (i in 1:length(At)) {
+          if (GQPop_At[At[i]] != 0) {
+            if (!(At[i] %in% AreaType_)) {
+              PopToShift <- GQPop_At[At[i]]
+              GQPop_At[At[i]] <- 0
+              GQPop_At[At[i + 1]] <- GQPop_At[At[i + 1]] + PopToShift
+            }
+          }
+        }
         GQBzones_ <- sample(unlist(sapply(At, function(x) {
           sample(Bzones_[AreaType_ == x],
                  GQPop_At[x],

--- a/sources/modules/VETravelPerformance/DESCRIPTION
+++ b/sources/modules/VETravelPerformance/DESCRIPTION
@@ -2,7 +2,7 @@ Package: VETravelPerformance
 Type: Package
 Title: Balances cost and travel and calculates travel performance measures
 Version: 0.9.5
-Date: 02/13/20
+Date: 06/05/20
 Author: Brian Gregor [aut, cre],
 Maintainer: Brian Gregor <gregorb@or-analytics.com>
 Copyright: AASHTO

--- a/sources/modules/VETravelPerformance/R/BudgetHouseholdDvmt.R
+++ b/sources/modules/VETravelPerformance/R/BudgetHouseholdDvmt.R
@@ -5,7 +5,7 @@
 #<doc>
 #
 ## BudgetHouseholdDvmt Module
-#### January 23, 2019
+#### June 5, 2020
 #
 #This module adjusts average household DVMT to keep the quantity within the limit of the household vehicle operating cost budget. A linear regression model is applied to calculate the maximum proportion of income that the household is willing to pay for vehicle operations. This proportion is multiplied by household income (with adjustments explained below) to calculate the maximum amount the household is willing to spend. This is compared to the vehicle operating cost calculated for the household. If the household vehicle operating cost is greater than the maximum amount the household is willing to pay, the household DVMT is reduced to fit within the budget.
 #
@@ -348,7 +348,7 @@ BudgetHouseholdDvmtSpecifications <- list(
       GROUP = "Year",
       TYPE = "currency",
       UNITS = "USD.2001",
-      PROHIBIT = c("NA", "< 0"),
+      PROHIBIT = c("< 0"),
       ISELEMENTOF = ""
     ),
     item(
@@ -375,7 +375,7 @@ BudgetHouseholdDvmtSpecifications <- list(
       GROUP = "Year",
       TYPE = "compound",
       UNITS = "GGE/MI",
-      PROHIBIT = c("NA", "< 0"),
+      PROHIBIT = c("< 0"),
       ISELEMENTOF = ""
     ),
     item(
@@ -384,7 +384,7 @@ BudgetHouseholdDvmtSpecifications <- list(
       GROUP = "Year",
       TYPE = "compound",
       UNITS = "KWH/MI",
-      PROHIBIT = c("NA", "< 0"),
+      PROHIBIT = c("< 0"),
       ISELEMENTOF = ""
     ),
     item(
@@ -393,7 +393,7 @@ BudgetHouseholdDvmtSpecifications <- list(
       GROUP = "Year",
       TYPE = "compound",
       UNITS = "GM/MI",
-      PROHIBIT = c("NA", "< 0"),
+      PROHIBIT = c("< 0"),
       ISELEMENTOF = ""
     ),
     item(
@@ -661,6 +661,10 @@ BudgetHouseholdDvmt <- function(L, M) {
     BudgetDvmt_Hh <- VehOpBudget_Hh / L$Year$Household$AveVehCostPM / 365
     #Adjusted DVMT is the minimum of the 'budget' DVMT and 'modeled' DVMT
     AdjDvmt_Hh <- pmin(BudgetDvmt_Hh, Dvmt_Hh)
+    #Remove NA from AdjDvmt_Hh. These are group quarters population less than
+    #15 years old that don't have vehicle access. As a result, they have NA
+    #values for AveVehCostPM. So set their values for AdjDvmt_Hh equal to 0
+    AdjDvmt_Hh[is.na(AdjDvmt_Hh)] <- 0
     #Establish a lower minimum to avoid zero values
     MinDvmt <- quantile(AdjDvmt_Hh, 0.01)
     AdjDvmt_Hh[AdjDvmt_Hh < MinDvmt] <- MinDvmt
@@ -693,15 +697,24 @@ BudgetHouseholdDvmt <- function(L, M) {
   L$CalcAltTrips$Year$Household$Dvmt <- Adj_ls$Dvmt_Hh
   AltTrips_ls <- M$CalcAltTrips(L$CalcAltTrips)$Year$Household
 
+  #Calculate DailyGGE, DailyKWH, DailyCO2e
+  #---------------------------------------
+  DailyGGE_Hh <- Adj_ls$Dvmt_Hh * L$Year$Household$AveGPM
+  DailyGGE_Hh[is.na(L$Year$Household$AveGPM)] <- 0
+  DailyKWH_Hh <- Adj_ls$Dvmt_Hh * L$Year$Household$AveKWHPM
+  DailyKWH_Hh[is.na(L$Year$Household$AveKWHPM)] <- 0
+  DailyCO2e_Hh <- Adj_ls$Dvmt_Hh * L$Year$Household$AveCO2ePM
+  DailyCO2e_Hh[is.na(L$Year$Household$AveCO2ePM)] <- 0
+
   #Return the results
   #------------------
   #Initialize output list
   Out_ls <- initDataList()
   Out_ls$Year$Household <- list(
     Dvmt = Adj_ls$Dvmt_Hh,
-    DailyGGE = Adj_ls$Dvmt_Hh * L$Year$Household$AveGPM,
-    DailyKWH = Adj_ls$Dvmt_Hh * L$Year$Household$AveKWHPM,
-    DailyCO2e = Adj_ls$Dvmt_Hh * L$Year$Household$AveCO2ePM,
+    DailyGGE = DailyGGE_Hh,
+    DailyKWH = DailyKWH_Hh,
+    DailyCO2e = DailyCO2e_Hh,
     VehicleTrips = VehicleTrips_Hh,
     WalkTrips = AltTrips_ls$WalkTrips,
     BikeTrips = AltTrips_ls$BikeTrips,

--- a/sources/modules/VETravelPerformance/R/CalculateRoadDvmt.R
+++ b/sources/modules/VETravelPerformance/R/CalculateRoadDvmt.R
@@ -5,7 +5,7 @@
 #<doc>
 #
 ## CalculateRoadDvmt Module
-#### January 27, 2019
+#### June 5, 2020
 #
 #When run for the base year, this module computes several factors used in computing roadway DVMT including factors for calculating commercial service vehicle travel and heavy truck travel. While base year heavy truck DVMT and commercial service vehicle DVMT are calculated directly from inputs and model parameters, future year DVMT is calculated as a function of the declared growth basis which for heavy trucks may be population or income, and for commercial service vehicles may be population, income, or household DVMT. Factors are calculated for each basis. In non-base years, the module uses these factors to compute heavy truck and commercial service DVMT.
 #
@@ -579,20 +579,26 @@ assignHhUrbanDvmtProp <- function(Hh_ls, HhUrbanRoadDvmt_Ma) {
       Dvmt_ <- Hh_ls$Dvmt[Hh_ls$Marea == ma]
       LocType_ <- Hh_ls$LocType[Hh_ls$Marea == ma]
       Prob_ <- as.numeric(LocType_ == "Urban")
-      UrbanRoadProp_ <- Prob_ * HhUrbanRoadDvmt_Ma[ma] / sum(Dvmt_ * Prob_)
-      if (any(UrbanRoadProp_ > 1)) {
+      if (any(Prob_ == 1)) {
+        UrbanRoadProp_ <- Prob_ * HhUrbanRoadDvmt_Ma[ma] / sum(Dvmt_ * Prob_)
+        if (any(UrbanRoadProp_ > 1)) {
+          UrbanRoadProp_[UrbanRoadProp_ > 1] <- 1
+          RoadDvmtDiff <- HhUrbanRoadDvmt_Ma[ma] - sum(UrbanRoadProp_ * Dvmt_)
+          UrbanRoadProp_[LocType_ != "Urban"] <-
+            RoadDvmtDiff / sum(Dvmt_[LocType_ != "Urban"])
+        }
         UrbanRoadProp_[UrbanRoadProp_ > 1] <- 1
-        RoadDvmtDiff <- HhUrbanRoadDvmt_Ma[ma] - sum(UrbanRoadProp_ * Dvmt_)
-        UrbanRoadProp_[LocType_ != "Urban"] <-
-          RoadDvmtDiff / sum(Dvmt_[LocType_ != "Urban"])
+        HhDvmt_ <- tapply(Dvmt_, LocType_, sum)
+        HhUrbanDvmt_ <- tapply(UrbanRoadProp_ * Dvmt_, LocType_, sum)
+        Prop_[Hh_ls$Marea == ma] <- UrbanRoadProp_
+        UrbanHhPropUrbanDvmt_Ma[ma] <- HhUrbanDvmt_["Urban"] / HhDvmt_["Urban"]
+        NonUrbanHhPropUrbanDvmt_Ma[ma] <-
+          (sum(HhUrbanDvmt_) - HhUrbanDvmt_["Urban"])  / (sum(HhDvmt_) - HhDvmt_["Urban"])
+      } else {
+        Prop_[Hh_ls$Marea == ma] <- HhUrbanRoadDvmt_Ma[ma] / sum(Dvmt_)
+        UrbanHhPropUrbanDvmt_Ma[ma] <- 0
+        NonUrbanHhPropUrbanDvmt_Ma[ma] <- HhUrbanRoadDvmt_Ma[ma] / sum(Dvmt_)
       }
-      UrbanRoadProp_[UrbanRoadProp_ > 1] <- 1
-      HhDvmt_ <- tapply(Dvmt_, LocType_, sum)
-      HhUrbanDvmt_ <- tapply(UrbanRoadProp_ * Dvmt_, LocType_, sum)
-      Prop_[Hh_ls$Marea == ma] <- UrbanRoadProp_
-      UrbanHhPropUrbanDvmt_Ma[ma] <- HhUrbanDvmt_["Urban"] / HhDvmt_["Urban"]
-      NonUrbanHhPropUrbanDvmt_Ma[ma] <-
-        (sum(HhUrbanDvmt_) - HhUrbanDvmt_["Urban"])  / (sum(HhDvmt_) - HhDvmt_["Urban"])
     } else {
       Prop_[Hh_ls$Marea == ma] <- 0
       UrbanHhPropUrbanDvmt_Ma[ma] <- 0

--- a/sources/modules/VETravelPerformance/R/CalculateVehicleOperatingCost.R
+++ b/sources/modules/VETravelPerformance/R/CalculateVehicleOperatingCost.R
@@ -5,7 +5,7 @@
 #<doc>
 #
 ## CalculateHhVehicleOperatingCosts Module
-#### January 23, 2019
+#### June 5, 2020
 #
 #This module calculates vehicle operating costs per mile of travel and uses those costs to determine the proportional split of DVMT among household vehicles. The module also calculates the average out-of-pocket costs per mile of vehicle travel by household, as well as the cost of social and environmental impacts, and road use taxes per mile of vehicle travel.
 #
@@ -966,7 +966,7 @@ CalculateVehicleOperatingCostSpecifications <- list(
       TYPE = "currency",
       UNITS = "USD.2010",
       NAVALUE = -1,
-      PROHIBIT = c("NA", "< 0"),
+      PROHIBIT = c("< 0"),
       ISELEMENTOF = "",
       SIZE = 0,
       DESCRIPTION = "Average out-of-pocket cost in dollars per mile of vehicle travel"
@@ -978,7 +978,7 @@ CalculateVehicleOperatingCostSpecifications <- list(
       TYPE = "currency",
       UNITS = "USD.2010",
       NAVALUE = -1,
-      PROHIBIT = c("NA", "< 0"),
+      PROHIBIT = c("< 0"),
       ISELEMENTOF = "",
       SIZE = 0,
       DESCRIPTION = "Average cost in dollars of the social and environmental impacts per mile of vehicle travel"
@@ -990,7 +990,7 @@ CalculateVehicleOperatingCostSpecifications <- list(
       TYPE = "currency",
       UNITS = "USD.2010",
       NAVALUE = -1,
-      PROHIBIT = c("NA", "< 0"),
+      PROHIBIT = c("< 0"),
       ISELEMENTOF = "",
       SIZE = 0,
       DESCRIPTION = "Average road use taxes in dollars collected per mile of vehicle travel"
@@ -1014,7 +1014,7 @@ CalculateVehicleOperatingCostSpecifications <- list(
       TYPE = "compound",
       UNITS = "GGE/MI",
       NAVALUE = -1,
-      PROHIBIT = c("NA", "< 0"),
+      PROHIBIT = c("< 0"),
       ISELEMENTOF = "",
       SIZE = 0,
       DESCRIPTION = "Average gasoline equivalent gallons per mile of household vehicle travel"
@@ -1026,7 +1026,7 @@ CalculateVehicleOperatingCostSpecifications <- list(
       TYPE = "compound",
       UNITS = "KWH/MI",
       NAVALUE = -1,
-      PROHIBIT = c("NA", "< 0"),
+      PROHIBIT = c("< 0"),
       ISELEMENTOF = "",
       SIZE = 0,
       DESCRIPTION = "Average kilowatt-hours per mile of household vehicle travel"
@@ -1038,7 +1038,7 @@ CalculateVehicleOperatingCostSpecifications <- list(
       TYPE = "compound",
       UNITS = "GM/MI",
       NAVALUE = -1,
-      PROHIBIT = c("NA", "< 0"),
+      PROHIBIT = c("< 0"),
       ISELEMENTOF = "",
       SIZE = 0,
       DESCRIPTION = "Average grams of carbon-dioxide equivalents produced per mile of household vehicle travel"


### PR DESCRIPTION
…e_gq_pop-prop_by_area-type.csv' file name. Change date in DESCRIPTION and module comments to reflect date of correction.

Model initialization was failing when the 'azone_gq_pop-prop_by_area-type.csv' file was present in user inputs. Failure occurred because when the file is present, it is checked to make sure that the population proportions by area type add up to 1 for each Azone. This is done in the Initialize module by calling the checkProps function that is defined in the module. This function is defined to have 3 parameters. However, the erroneous code called the function with only 2 arguments. Missing was the 'File' argument. The code was corrected by adding in the proper argument to the call.