### PR TITLE
Proposed check for Rtools on Windows

### DIFF
--- a/build/VisionEval-dev.R
+++ b/build/VisionEval-dev.R
@@ -46,6 +46,11 @@ evalq(
       r.home <- Sys.getenv("R_HOME")
       tryCatch(
         { 
+          if(Sys.info()['sysname'] == 'Windows' & 
+             !grepl('rtools', Sys.which('make'))){
+            stop('Please install Rtools for Windows, and make sure it is available in the system PATH. \n https://cran.r-project.org/bin/windows/Rtools/')
+          }
+          
           if ( length(r.version)>0 ) {
             r.version <- r.version[1] # only the first is used
             Sys.setenv(VE_R_VERSION=r.version)


### PR DESCRIPTION
Hadn't yet installed Rtools on this machine (recently new), so adding this check to notify others with potentially same issue.

@jrawbits This works as expected on my Windows machine (exits `ve.build` with an informative error if rtools not found), please take a look and see if this works for you.