### PR TITLE
Indexing error in VELandUse::PredictHousing.R ipf function

### DIFF
--- a/sources/modules/VELandUse/R/PredictHousing.R
+++ b/sources/modules/VELandUse/R/PredictHousing.R
@@ -70,6 +70,7 @@
 #' Summary: the summary of the binomial model estimation results.
 #' @import visioneval stats
 #' @importFrom utils capture.output
+
 #Define function to estimate the income model
 estimateHousingModel <- function(Data_df, StartTerms_) {
   #Define function to prepare inputs for estimating model
@@ -563,7 +564,7 @@ ipf <-
     #Eliminate zero values in margins
     MrgnVals_ls <-
       lapply(MrgnVals_ls, function(x) {
-        x[x = 0] <- 1e-6
+        x[x == 0] <- 1e-6
         x
       })
     #Starting value for Units_ar


### PR DESCRIPTION
In VELandUse::PredictHousing.R, the ipf function has a helper function intended to sweep out zeroes in the seed matrix, replacing them with a very tiny value (1e-6) so the zero cells can still receive tiny values. Due to an indexing error (x=0 versus x==0), the function does nothing and zeroes remain untouched in the seed matrix.

Because this bug has the potential to change the resulting fitted matrix (and potentially change the model results perceptibly), I'm not just pushing it straight into development. We'll need to build the fix and compare results with a seed matrix that contains zeroes and see how much the key metrics change...