### PR TITLE
Fixed a data preparation bug found in VETravelDemandMM package

### DIFF
--- a/sources/modules/VETravelDemandMM/R/CalculateAltModeTrips.R
+++ b/sources/modules/VETravelDemandMM/R/CalculateAltModeTrips.R
@@ -222,6 +222,15 @@ CalculateAltModeTripsSpecifications <- list(
       ISELEMENTOF = ""
     ),
     visioneval::item(
+      NAME = "Marea",
+      TABLE = "Household",
+      GROUP = "Year",
+      TYPE = "character",
+      UNITS = "ID",
+      PROHIBIT = "",
+      ISELEMENTOF = ""
+    ),
+    visioneval::item(
       NAME = "LocType",
       TABLE = "Household",
       GROUP = "Year",
@@ -554,15 +563,14 @@ CalculateAltModeTrips <- function(L) {
            AADVMT = Dvmt,
            LogIncome=log1p(Income),
            DrvAgePop=HhSize - Age0to14,
-           VehPerDriver=ifelse(Drivers==0 || is.na(Drivers), 0, Vehicles/Drivers),
+           VehPerDriver=ifelse(Drivers==0 | is.na(Drivers), 0, Vehicles/Drivers),
            LifeCycle = as.character(LifeCycle),
            LifeCycle = ifelse(LifeCycle=="01", "Single", LifeCycle),
            LifeCycle = ifelse(LifeCycle %in% c("02"), "Couple w/o children", LifeCycle),
            LifeCycle = ifelse(LifeCycle %in% c("00", "03", "04", "05", "06", "07", "08"), "Parents w/ children", LifeCycle),
            LifeCycle = ifelse(LifeCycle %in% c("09", "10"), "Empty Nester", LifeCycle)
     ) %>%
-    left_join(Bzone_df, by="Bzone") %>%
-    crossing(Marea_df)
+    left_join(Bzone_df, by="Bzone") %>% left_join(Marea_df, by="Marea")
   
   #D_df <- D_df %>%
   #  crossing(Marea_df, by="Marea")

--- a/sources/modules/VETravelDemandMM/R/CalculateHouseholdDvmt.R
+++ b/sources/modules/VETravelDemandMM/R/CalculateHouseholdDvmt.R
@@ -403,7 +403,7 @@ CalculateHouseholdDvmt <- function(L) {
     mutate(metro=ifelse(LocType=="Urban", "metro", "non_metro"),
            LogIncome=log1p(Income),
            DrvAgePop=HhSize - Age0to14,
-           VehPerDriver=ifelse(Drivers==0 || is.na(Drivers), 0, Vehicles/Drivers),
+           VehPerDriver=ifelse(Drivers==0 | is.na(Drivers), 0, Vehicles/Drivers),
            LifeCycle = as.character(LifeCycle),
            LifeCycle = ifelse(LifeCycle=="01", "Single", LifeCycle),
            LifeCycle = ifelse(LifeCycle %in% c("02"), "Couple w/o children", LifeCycle),


### PR DESCRIPTION
During the data preparation process to apply AADVMT model the VehPerDriver variable was evaluated to 0 for all households because the operator || was incorrectly specified. The operator was corrected in this commit. (originally submitted ax a pull request against the development branch by @goreaditya).